### PR TITLE
v050d

### DIFF
--- a/main.c
+++ b/main.c
@@ -1931,10 +1931,15 @@ int main(int argc, const char** argv)
         }
     }
 
-    if (alchemizer || placement_file) {
-        printf("Applying alchemizer...\n");
-        grow = true;
+    if (randomized || energy_core == ENERGY_CORE_FRAGMENTS) {
+        // ALCHEMY_RANDO_DROPS57 is required for fragments
+        if (alchemizer) {
+            printf("Applying alchemizer...\n");
+        } else {
+            printf("Fixing alchemists...\n");
+        }
 
+        grow = true;
         for (uint8_t i=0; i<ALCHEMY_COUNT; i++) {
             // Replace alchemy flags by location flags
             // new flags at $7e2570..74
@@ -1960,16 +1965,13 @@ int main(int argc, const char** argv)
             call_setup[1] = (uint8_t)(setup_tgt>>0);
             call_setup[2] = (uint8_t)(setup_tgt>>8);
             call_setup[3] = (uint8_t)(setup_tgt>>16);
-            memcpy(buf + rom_off + drop_dst + 0, call_setup, sizeof(call_setup)); // TODO: fill in address
+            memcpy(buf + rom_off + drop_dst + 0, call_setup, sizeof(call_setup));
             memcpy(buf + rom_off + drop_dst + 4, call_drop,  sizeof(call_drop));
         }
 
         // Make alchemy become items
         APPLY_ALCHEMY_TEXTS();
         APPLY_ALCHEMY_RANDO_DROPS(); // this has to be applied after changing the alchemy flags
-    } else if (energy_core == ENERGY_CORE_FRAGMENTS) {
-        grow = true;
-        APPLY(ALCHEMY_RANDO_DROPS57); // this is required for the energy core drop
     }
 
     if (ingredienizer) {

--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 // see google doc for documentation on old (numbered) patches
 // the idea is to "manually" patch the game to a state where we simply swap
 // out some numbers to make it random (without rewriting/relocating everything)
-#define VERSION "v049"
+#define VERSION "v050d"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -2260,7 +2260,7 @@ int main(int argc, const char** argv)
         len = fwrite(buf, 1, sz, fdst);
         fclose(fdst); fdst=NULL;
         if (len<sz) { fclose(fsrc); free(buf); die("Could not write output file!\n"); }
-        printf("Rom saved as %s!\n", dst);
+        printf("Rom saved as %s !\n", dst);
     }
     
     // write spoiler log
@@ -2364,7 +2364,7 @@ int main(int argc, const char** argv)
     }
     #undef ENDL
     fclose(flog); flog=NULL;
-    printf("Spoiler log saved as %s!\n", logdstbuf);
+    printf("Spoiler log saved as %s !\n", logdstbuf);
     free(logdstbuf);
     }
 

--- a/main.c
+++ b/main.c
@@ -240,12 +240,12 @@ struct preset {const char* name; const char* settings; int exp; int money;};
 const static struct preset presets[] = {
     {"First-Timer", "rel", 300, 300},
     {"Beginner", "rel", 200, 250},
-    {"Advanced", "rlABGSCd67", 150, 200},
-    {"Pro", "rhlABGISCD567", 125, 150},
-    {"Hell", "rhlABGOISCp567f", 75, 75},
-    {"Menblock", "rhlABGOISCp567f", 1, 1},
-    {"Turdo", "rxlABGoISCDm567t", 125, 200},
-    {"Full Random", "rxlABGoISCDm67", -1, -1} //-1 => weekly-esque random value
+    {"Advanced", "rlABGvCd67", 150, 200},
+    {"Pro", "rhlABGIvCD567", 125, 150},
+    {"Hell", "rhlABGOISvCp567f", 75, 75},
+    {"Menblock", "rhlABGOISvCp567f", 1, 1},
+    {"Turdo", "rxlABGoISvCDm567t", 125, 200},
+    {"Full Random", "rxlABGoISvCDm67", -1, -1} //-1 => weekly-esque random value
 };
 #endif
 


### PR DESCRIPTION
* remove 'Pool' sniff spots, add 'Random Ingredients' for 'Advanced' and 'Pro' restoring pre-v048 behaviour
* add 'Random Ingredients' to 'Hell', 'Menblock', 'Turdo' and 'Full Random'
* always apply alchemizer fixes/flags
  * this fixes some auto-tracking issues
  * this fixes Sting not pre-selecting Sting in the alchemy menu
* add extra space to filename output to allow easier copy and paste
  * **this requires update of wasm/ui.js**